### PR TITLE
Rewrite to accommodate ActiveSupport 4.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,6 @@
-require 'bundler'
-include Rake::DSL
-
-Bundler::GemHelper.install_tasks
-
+require 'bundler/gem_tasks'
 require 'rake/testtask'
-Rake::TestTask.new("test") do |test|
-  test.pattern = "test/**/*_test.rb"
-  test.verbose = true
+
+Rake::TestTask.new do |t|
+  t.test_files = FileList['test/*_test.rb']
 end

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@ require 'rake/testtask'
 Rake::TestTask.new do |t|
   t.test_files = FileList['test/*_test.rb']
 end
+
+task default: :test

--- a/lib/yaml_record.rb
+++ b/lib/yaml_record.rb
@@ -1,12 +1,13 @@
-require 'active_support/core_ext/kernel'
-require 'active_support/core_ext/class'
-require 'active_support/core_ext/hash'
-require 'active_support/secure_random'
+require 'active_support'
 require 'active_support/callbacks'
+require 'active_support/core_ext/hash'
+require 'securerandom'
 require 'yaml'
 
+require 'yaml_record/version'
+require 'yaml_record/base'
+require 'yaml_record/adapters/local_store'
+require 'yaml_record/adapters/redis_store'
+
 module YamlRecord
-  require File.dirname(__FILE__) + "/yaml_record/base"
-  require File.dirname(__FILE__) + "/yaml_record/adapters/redis_store"
-  require File.dirname(__FILE__) + "/yaml_record/adapters/local_store"
 end

--- a/lib/yaml_record/base.rb
+++ b/lib/yaml_record/base.rb
@@ -5,7 +5,7 @@ module YamlRecord
     include ActiveSupport::Callbacks
     define_callbacks :before_save, :after_save, :before_destroy, :after_destroy, :before_validation, :before_create, :after_create
 
-    before_create :set_id!
+    set_callback :before_create, :before, :set_id!
 
     # Constructs a new YamlRecord instance based on specified attribute hash
     #
@@ -401,7 +401,7 @@ module YamlRecord
     # Protected method, not called during usage
     #
     def set_id!
-      self.id = ActiveSupport::SecureRandom.hex(15)
+      self.id = SecureRandom.hex(15)
     end
   end
 end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -5,7 +5,7 @@ class YamlObject < YamlRecord::Base
   source File.dirname(__FILE__) + "/../tmp/yaml_object"
 end
 
-class BaseTest < Test::Unit::TestCase
+class BaseTest < Minitest::Test
 
   def setup
     @obj_title = "Simple Title"
@@ -48,7 +48,7 @@ class BaseTest < Test::Unit::TestCase
         @fs2.save
       end
 
-      should("save on yaml file"){ assert_equal YamlObject.last.attributes.diff(@attr), {:id => @fs2.reload.id } }
+      should("save on yaml file"){ assert_equal YamlObject.last.id, @fs2.reload.id }
     end
 
     context "for update_attributes method" do
@@ -196,7 +196,7 @@ class BaseTest < Test::Unit::TestCase
         assert_kind_of YamlRecord::Adapters::LocalStore, YamlOtherObject.adapter
       end
       should("not support invalid adapter") do
-        assert_raise(NameError) { class YamlFakeObject < YamlRecord::Base; adapter(:fake); end }
+        assert_raises(NameError) { class YamlFakeObject < YamlRecord::Base; adapter(:fake); end }
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,12 @@
-require 'rubygems'
-require 'test/unit'
+require 'minitest/autorun'
 require 'shoulda'
-require File.dirname(__FILE__) + "/../lib/yaml_record"
+require 'yaml_record'
 
-class Test::Unit::TestCase
+class Minitest::Test
   def clean_yaml_record(class_record)
     File.open(class_record.source, 'w') {|f| f.write(nil) }
   end
-  
+
   # Asserts that the condition is not true
   # assert_false @title == "hey"
   def assert_false(condition, message=nil)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ require 'yaml_record'
 
 class Minitest::Test
   def clean_yaml_record(class_record)
+    dir = File.dirname(class_record.source)
+    Dir.mkdir(dir) unless Dir.exists?(dir)
     File.open(class_record.source, 'w') {|f| f.write(nil) }
   end
 

--- a/yaml_record.gemspec
+++ b/yaml_record.gemspec
@@ -1,25 +1,26 @@
-# -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "yaml_record/version"
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'yaml_record/version'
 
-Gem::Specification.new do |s|
-  s.name        = "yaml_record"
-  s.version     = YamlRecord::VERSION
-  s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Nico Taing", "Nathan Esquenazi"]
-  s.email       = ["nico@gomiso.com"]
-  s.homepage    = "https://github.com/nico-taing/yaml_record"
-  s.summary     = %q{YAML file persistence engine}
-  s.description = %q{Use YAML for persisted data with ActiveModel interface}
+Gem::Specification.new do |spec|
+  spec.name          = "yaml_record"
+  spec.version       = YamlRecord::VERSION
+  spec.authors       = ["Nico Taing", "Nathan Esquenazi"]
+  spec.email         = ["nico@gomiso.com"]
+  spec.summary       = %q{YAML file persistence engine}
+  spec.description   = %q{Use YAML for persisted data with ActiveModel interface}
+  spec.homepage      = "https://github.com/nico-taing/yaml_record"
+  spec.license       = "MIT"
 
-  s.rubyforge_project = "yaml_record"
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
-  
-  s.add_dependency 'activesupport', '~> 2.3.11'
-  s.add_development_dependency 'rake', '~> 0.9.2'
-  s.add_development_dependency 'shoulda'
+  spec.add_dependency 'activesupport', '~> 4.1.0'
+
+  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'shoulda', '~> 3.5.0'
 end


### PR DESCRIPTION
- Bump ActiveSupport requirement to 4.1
- Update gemspec to recent conventions
- Cleanup deprecated libraries and methods, including using
  Minitest::Test instead of Test::Unit

(Ensured all existing tests ran successfully)
